### PR TITLE
Fix syntaxe error

### DIFF
--- a/app/controllers/v1/establishment_controller.rb
+++ b/app/controllers/v1/establishment_controller.rb
@@ -7,18 +7,14 @@ module V1
     def index
       @establishments = Establishment.all
 
-      render json: {
-        establishments = @establishments
-      }
+      render json: @establishments
     end
 
     def show
       if @establishment.blank?
         head :not_found
       else
-        render json: {
-          establishment = @establishment
-        }
+        render json: @establishment
       end
     end
 


### PR DESCRIPTION
This fixes an error we discovered on Heroku:

![image](https://user-images.githubusercontent.com/523071/87788888-871dce00-c814-11ea-8b33-c3d480d3d4e9.png)
